### PR TITLE
Switch to devcontainer spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,21 +6,22 @@
   ],
   "service": "hardhat-repo-template",
   "workspaceFolder": "/utkusarioglu/templates/hardhat-repo-template",
-  "settings": {
-    "workbench.colorCustomizations": {
-      "activityBar.background": "#ddb01b",
-      "activityBar.foreground": "#000000"
-    }
-  },
-  "extensions": [
-    "JuanBlanco.solidity",
-    "MythX.mythxvsc",
-    "joaompinto.vscode-graphviz",
-    "cschleiden.vscode-github-actions",
-    "GitHub.vscode-pull-request-github"
-  ],
   "postCreateCommand": "scripts/post-create-command.sh",
-  "features": {
-    "github-cli": "latest"
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "workbench.colorCustomizations": {
+          "activityBar.background": "#ddb01b",
+          "activityBar.foreground": "#000000"
+        }
+      },
+      "extensions": [
+        "JuanBlanco.solidity",
+        "MythX.mythxvsc",
+        "joaompinto.vscode-graphviz",
+        "cschleiden.vscode-github-actions",
+        "GitHub.vscode-pull-request-github"
+      ],
+    }
   }
 }

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   hardhat-repo-template:
-    image: utkusarioglu/ethereum-devcontainer:1.0.3
+    image: utkusarioglu/ethereum-devcontainer:1.0.4
     volumes:
       - ..:/utkusarioglu/templates/hardhat-repo-template


### PR DESCRIPTION
This PR refactors `devcontainer.json` to comply with the new devcontainer specs.
PR also bumps the docker image version from `1.0.3` to `1.0.4` to pull the
latest image, which supports devcontainer feature for github-cli and ssh for
codespaces.
