### PR TITLE
Upgrade CI image versions

### DIFF
--- a/.github/workflows/mythril-analyze.yml
+++ b/.github/workflows/mythril-analyze.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run Mythril analysis
     runs-on: ubuntu-latest
     container:
-      image: utkusarioglu/ethereum-devcontainer:latest
+      image: utkusarioglu/ethereum-devcontainer:1.0.4
       env:
         COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
         INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}

--- a/.github/workflows/slither-analyze.yml
+++ b/.github/workflows/slither-analyze.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run Slither analysis
     runs-on: ubuntu-latest
     container:
-      image: utkusarioglu/ethereum-devcontainer:latest
+      image: utkusarioglu/ethereum-devcontainer:1.0.4
       options: --user=0:0
       env:
         COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     container:
-      image: utkusarioglu/ethereum-devcontainer:latest
+      image: utkusarioglu/ethereum-devcontainer:1.0.4
       options: --user=0:0
       env:
         COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}


### PR DESCRIPTION
This PR updates the version of the `ethereum-devcontainer` image in related workflows. The old `latest` version is causing failure in repos that consume this template as the referenced docker image does not carry the `latest` tag anymore.
