### PR TITLE
Chore: Update devcontainer config

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,12 +1,19 @@
 version: "3.9"
 services:
   hardhat-repo-template:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
-      - vscode-extensions:/root/.vscode-server/extensions
-      - vscode-extensions-insiders:/root/.vscode-server-insiders/extensions
-      - ~/.config/gh:/home/hardhat/.config/gh:ro
+      - type: volume
+        source: vscode-server-extensions
+        target: ${HOME}/.vscode-server/extensions
+      - type: volume
+        source: vscode-server-insiders-extensions
+        target: ${HOME}/.vscode-server-insiders/extensions
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:
-  vscode-extensions:
-  vscode-extensions-insiders:
+  vscode-server-extensions:
+    name: hardhat-repo-template-vscode-server-extensions
+  vscode-server-insiders-extensions:
+    name: hardhat-repo-template-vscode-server-extensions-insiders

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   hardhat-repo-template:
-    image: utkusarioglu/ethereum-devcontainer:1.0.4
+    image: utkusarioglu/ethereum-devcontainer:1.0.5
     volumes:
       - ..:/utkusarioglu/templates/hardhat-repo-template


### PR DESCRIPTION
- Remove github config path mount and replace it with environment
  variable `GH_TOKEN`. This is done to make sure that the template is
  compatible with codespaces.
- Rewrite other paths in docker compose files with long syntax. This is
  done to ease the burden of value replacement that is done by template
  updater.
- Upgrade to devcontainer image 1.0.5.
- Define names for vscode extensions mounts in docker compose.
