### PR TITLE
Feat: Update Echidna analysis script

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   hardhat-repo-template:
-    image: utkusarioglu/ethereum-devcontainer:1.0.5
+    image: utkusarioglu/ethereum-devcontainer:1.0.6
     volumes:
       - ..:/utkusarioglu/templates/hardhat-repo-template

--- a/scripts/echidna-analyze.sh
+++ b/scripts/echidna-analyze.sh
@@ -1,33 +1,56 @@
 #!/bin/bash
 
 source /opt/venv/slither/bin/activate
+scripts/solc-select-install.sh
 
-ANALYSIS_FOLDER=./artifacts/echidna
-CONTRACTS="Main"
+ANALYSIS_ARTIFACTS_FOLDER="./artifacts/echidna"
+FUZZ_CONTRACT_SUFFIX="fuzz.test.sol"
+ANALYSIS_LOG_SUFFIX="analysis.log"
 
-mkdir -p $ANALYSIS_FOLDER
+tests_path=$(yarn -s hardhat config-value tests-path)
+sources_path=$(yarn -s hardhat config-value sources-path)
+current_date=$(date +%y%m%d-%H%M%S)
+contract_names=$(find $tests_path \
+  -name '*.fuzz.test.sol' \
+  -type f \
+  -exec sh -c "\
+    prefix_removed=\${0#\"$tests_path/\"}; \
+    suffix_removed=\${prefix_removed%\".$FUZZ_CONTRACT_SUFFIX\"}; \
+    echo \$suffix_removed; \
+  " {} \;)
 
-for SRC_CONTRACT in $CONTRACTS
+echo "Creating analysis artifacts folder: '$ANALYSIS_ARTIFACTS_FOLDER'…"
+mkdir -p "$ANALYSIS_ARTIFACTS_FOLDER"
+
+for contract_name in $contract_names
 do
-  FUZZ_CONTRACT_NAME="${SRC_CONTRACT}Fuzz"
-  FUZZ_CONTRACT_FILE="${SRC_CONTRACT}.fuzz.test.sol"
-  FUZZ_CONTRACT_PATH="tests/${FUZZ_CONTRACT_FILE}"
-  ANALYSIS_PATH="${ANALYSIS_FOLDER}/${SRC_CONTRACT}.analysis.txt"
+  source_contract_path="$sources_path/$contract_name.sol"
+  fuzz_contract_name="${contract_name}Fuzz"
+  fuzz_contract_file="$contract_name.$FUZZ_CONTRACT_SUFFIX"
+  fuzz_contract_path="$tests_path/$fuzz_contract_file"
+  analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
+  analysis_log_path="$ANALYSIS_ARTIFACTS_FOLDER/$analysis_log_filename"
 
-  if [ ! -f "$FUZZ_CONTRACT_PATH" ];
+  if [ ! -f "$fuzz_contract_path" ];
   then
-    echo "$FUZZ_CONTRACT_PATH is not available, skipping"
+    echo "$fuzz_contract_path is not available, skipping"
     continue 
   fi
 
-  echo "Testing: $FUZZ_CONTRACT_FILE"
+  if [ ! -f "$source_contract_path" ];
+  then
+    echo "$source_contract_path is not available, skipping"
+    continue 
+  fi
 
+  echo "Testing: '$fuzz_contract_file'…"
   echidna-test \
-    "$FUZZ_CONTRACT_PATH" \
-    --contract "$FUZZ_CONTRACT_NAME" \
+    "$fuzz_contract_path" \
+    --contract "$fuzz_contract_name" \
     --config echidna.config.yml \
     --test-mode property \
-    > "$ANALYSIS_PATH"
+    | tee "$analysis_log_path"
 
-  echo "Complete: $FUZZ_CONTRACT_FILE"
+  echo "Log saved to '$analysis_log_path'"
+  echo "Complete: $fuzz_contract_file."
 done


### PR DESCRIPTION
- Update Echidna analysis script to be entirely automated. Now there is
  no need to set the contracts, or adjust the paths. These are all
  either read from the fs or from hardhat config.
- Upgrade devcontainer image version to `1.0.6` as the fixes in this
  container image is required for Echidna to work as expected.
