### PR TITLE
Refactor: Remove solc-select from `postCreate…`

### DIFF
--- a/scripts/manticore-analyze.sh
+++ b/scripts/manticore-analyze.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /opt/venv/slither/bin/activate
+scripts/solc-select-install.sh
 
 # Goes through the contracts in `src/contracts` uses `solc.json` at repo 
 # root for remappings needed for `crytic-compile` to do its thing

--- a/scripts/mythril-analyze.sh
+++ b/scripts/mythril-analyze.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /opt/venv/mythril/bin/activate
+scripts/solc-select-install.sh
 
 # Goes through the contracts in `src/contracts` uses `solc.json` at repo 
 # root for remappings needed for `crytic-compile` to do its thing

--- a/scripts/post-create-command.sh
+++ b/scripts/post-create-command.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 yarn
-. scripts/solc-select-install.sh


### PR DESCRIPTION
- Remove solc-select commands from `postCreateCommand` and into scripts
  that need solc-select to run. This is done becase not every dev needs
  to run python based analyses on every session.
- This refactoring closes #10.
- Update `mythril-analyze.sh` and `manticore-analyze.sh` to include
  a call to `solc-select-install.sh`.
