### PR TITLE
Fix: Template updater adjustments behavior (2)

### DIFF
--- a/scripts/git-template-update-adjustments.sh
+++ b/scripts/git-template-update-adjustments.sh
@@ -31,7 +31,6 @@ do_adjustments() {
     echo "Warn: Skipping '$phrase' as something went wrong."
     continue
   fi
-  replacement=$repo_path
   echo "Replacing '$current' with '$replacement'…"
   find . -type f \( ! -iwholename "./scripts/setup.sh" ! -iname ".git" \) \
     -exec sed -i "s:$current:$replacement:g" {} \;


### PR DESCRIPTION
- Closes #23 by attempting another fix for the template updater
  adjustments script. The script was still broken because of a forgotten
  line of code nullifying the fix made in the previous commit.
