### PR TITLE
Chore: Move crytic exports path into `artifacts`

### DIFF
--- a/crytic.config.json
+++ b/crytic.config.json
@@ -1,4 +1,5 @@
 {
+  "export_dir": "artifacts/crytic-export",
   "solc_remaps": [
     "@openzeppelin/=./node_modules/@openzeppelin/",
     "hardhat/=./node_modules/hardhat/",


### PR DESCRIPTION
- Closes #34 by moving crytic exports into `artifacts/crytic-export`.
  Through crytic-compile's configuration file.
