### PR TITLE
Fix(updater): checks referencing obsolete config

### DIFF
--- a/.updater/checks.sh
+++ b/.updater/checks.sh
@@ -11,14 +11,13 @@ source .env 2> /dev/null
 source $REPO_CONFIG_FILE
 
 check_repo_config() {
-  if [ ! -f ".repo.config" ];
+  if [ ! -f "$REPO_CONFIG_FILE" ];
   then
-    echo "Error \`.repo.config\` file is required to configure the scripts' behavior"
+    echo "Error \`$REPO_CONFIG_FILE\` file is required to configure the scripts' behavior"
     exit 20
   fi
 
-  source .repo.config
-
+  source $REPO_CONFIG_FILE
 }
 
 check_repo_template_config() {


### PR DESCRIPTION
- Fix `checks.sh` checking for the existence of `.repo.config` file.
  This file was rendered obsolete by the introduction of
  `.repo-template.config`. The issue was resolved by converting the
  static file name to a variable, as it should have always been the
  case.
