### PR TITLE
Chore(devcontainer): Alter VS Color

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "vscode": {
       "settings": {
         "workbench.colorCustomizations": {
-          "activityBar.background": "#ddb01b",
+          "activityBar.background": "#EE0000",
           "activityBar.foreground": "#000000"
         }
       },


### PR DESCRIPTION
- Switch devcontainer color scheme to red as a part of the coloring
  convention for templates.
