### PR TITLE
Fix: Analysis tools run issues

### DIFF
--- a/crytic.config.json
+++ b/crytic.config.json
@@ -1,5 +1,4 @@
 {
-  "export_dir": "artifacts/crytic-export",
   "solc_remaps": [
     "@openzeppelin/=./node_modules/@openzeppelin/",
     "hardhat/=./node_modules/hardhat/",

--- a/scripts/analysis-common.sh
+++ b/scripts/analysis-common.sh
@@ -4,7 +4,11 @@ get_sources_path() {
 }
 
 get_contract_names() {
-  sources_path=$(get_sources_path)
+  sources_path=$1
+  if [ -z "$sources_path" ]; then
+    echo "Error: Function needs the first param to be the sources path"
+    exit 1
+  fi
   find $sources_path \
     -name '*.sol' \
     -type f \
@@ -13,10 +17,6 @@ get_contract_names() {
       suffix_removed=\${prefix_removed%\".sol\"}; \
       echo \$suffix_removed; \
     " {} \;
-}
-
-get_sources_path() {
-  yarn -s hardhat config-value sources-path
 }
 
 get_current_date_string() {
@@ -35,4 +35,22 @@ create_artifacts_subfolder() {
   artifacts_folder="artifacts/$artifacts_subfolder"
   mkdir -p "$artifacts_folder"
   echo "$artifacts_folder"
+}
+
+preprocess_contracts() {
+  target_path=$1
+  if [ -z "$target_path" ]; then 
+    echo "Error: Function needs target path as the first param"
+    exit 1
+  fi
+  mkdir -p $target_path
+  yarn hardhat preprocess --network geth1 --dest "$target_path"
+}
+
+get_solc_remaps() {
+  jq -r '.settings.remappings' solc.json
+}
+
+get_solc_remaps_joined() {
+  jq -r '.settings.remappings | join(" ")' solc.json
 }

--- a/scripts/echidna-analyze.sh
+++ b/scripts/echidna-analyze.sh
@@ -11,13 +11,12 @@ tests_path=$(get_tests_path)
 sources_path=$(get_sources_path)
 current_date=$(get_current_date_string)
 
-# echo "Creating analysis artifacts folder: '$ANALYSIS_ARTIFACTS_FOLDER'…"
-# mkdir -p "$ANALYSIS_ARTIFACTS_FOLDER"
 main() {
   artifacts_folder=$(create_artifacts_subfolder "echidna")
   echo "Created artifacts folder: '$artifacts_folder'…"
 
-  contract_names=$(get_contract_names)
+  sources_path=$(get_sources_path)
+  contract_names=$(get_contract_names $sources_path)
   echo "Found contracts: '$contract_names'"
 
   for contract_name in $contract_names

--- a/scripts/manticore-analyze.sh
+++ b/scripts/manticore-analyze.sh
@@ -7,13 +7,10 @@ scripts/solc-select-install.sh
 TEMP_SOLC_JSON_PATH="/tmp/solc-settings.json"
 ANALYSIS_LOG_SUFFIX="manticore.log"
 TIMEOUT_PER_CONTRACT=$(( 1 * 60 * 60 )) # 1 hour
+PREPROCESSED_CONTRACTS_PATH=/tmp/contracts
 
 sources_path=$(get_sources_path)
 current_date=$(get_current_date_string)
-
-get_solc_remaps() {
-  jq -r '.settings.remappings | join(" ")' solc.json
-}
 
 # Goes through the contracts in `src/contracts` uses `solc.json` at repo 
 # root for remappings needed for `crytic-compile` to do its thing
@@ -21,17 +18,20 @@ main() {
   artifacts_folder=$(create_artifacts_subfolder "manticore")
   echo "Created artifacts folder: '$artifacts_folder'…"
 
-  contract_names=$(get_contract_names)
+  preprocess_contracts $PREPROCESSED_CONTRACTS_PATH
+  contract_names=$(get_contract_names $PREPROCESSED_CONTRACTS_PATH)
   echo "Found contracts: '$contract_names'"
 
-  solc_remaps=$(get_solc_remaps)
+  solc_remaps=$(get_solc_remaps_joined)
   for contract_name in $contract_names;
   do
     echo "Testing: '$contract_name'…"
     source_contract_path="$sources_path/$contract_name.sol"
     analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
     analysis_log_path="$artifacts_folder/$analysis_log_filename"
-    mcore_workspace="$artifacts_folder/$current_date"
+    mcore_workspace="$artifacts_folder/$current_date/$contract_name"
+
+    mkdir -p "$mcore_workspace"
 
     manticore \
       --hardhat-cache-directory "$(pwd)/artifacts/cache" \

--- a/scripts/mythril-analyze.sh
+++ b/scripts/mythril-analyze.sh
@@ -6,6 +6,7 @@ scripts/solc-select-install.sh
 
 ANALYSIS_LOG_SUFFIX="mythril.log"
 TEMP_SOLC_JSON_PATH="/tmp/solc-settings.json"
+PREPROCESSED_CONTRACTS_PATH=/tmp/contracts
 
 current_date=$(get_current_date_string)
 sources_path=$(get_sources_path)
@@ -28,7 +29,8 @@ main() {
   artifacts_folder=$(create_artifacts_subfolder "mythril")
   echo "Created artifacts folder: '$artifacts_folder'…"
 
-  contract_names=$(get_contract_names)
+  preprocess_contracts $PREPROCESSED_CONTRACTS_PATH
+  contract_names=$(get_contract_names $PREPROCESSED_CONTRACTS_PATH)
   echo "Found contracts: '$contract_names'"
 
   for contract_name in $contract_names;

--- a/scripts/slither-analyze.sh
+++ b/scripts/slither-analyze.sh
@@ -5,6 +5,7 @@ source ${0%/*}/analysis-common.sh
 scripts/solc-select-install.sh
 
 ANALYSIS_LOG_SUFFIX="slither.log"
+PREPROCESSED_CONTRACTS_PATH=/tmp/contracts
 
 current_date=$(get_current_date_string)
 sources_path=$(get_sources_path)
@@ -20,7 +21,8 @@ main() {
   artifacts_folder=$(create_artifacts_subfolder "slither")
   echo "Created artifacts folder: '$artifacts_folder'…"
 
-  contract_names=$(get_contract_names)
+  preprocess_contracts $PREPROCESSED_CONTRACTS_PATH
+  contract_names=$(get_contract_names $PREPROCESSED_CONTRACTS_PATH)
   echo "Found contracts: '$contract_names'"
 
   for contract_name in $contract_names;


### PR DESCRIPTION
- Add lines related to preprocessing the contracts through hardhat in
  the files:
  * analysis-common.sh
  * echidna-analyze.sh
  * manticore-analyze.sh
  * mythril-analyze.sh
  * slither-analyze.sh
- Remove `export_dir` config from `crytic.config.json` as this setting
  causes issues in echidna.
- Remove function `get_sources_path` in `analysis-common.sh`. This
  function was defined twice.
- Create another level of path for manticore artifacts that reflect the
  name of the contract that was analyzed. This is done because manticore
  creates a lot of files and it can be hard to understand to what
  contract a given file belongs to when they are dumped all in the same
  folder. This new path level eliminates this issue.
