### PR TITLE
Fix: Mythril, Manticore, Slither contract path

### DIFF
--- a/scripts/manticore-analyze.sh
+++ b/scripts/manticore-analyze.sh
@@ -26,7 +26,7 @@ main() {
   for contract_name in $contract_names;
   do
     echo "Testing: '$contract_name'…"
-    source_contract_path="$sources_path/$contract_name.sol"
+    source_contract_path="$PREPROCESSED_CONTRACTS_PATH/$contract_name.sol"
     analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
     analysis_log_path="$artifacts_folder/$analysis_log_filename"
     mcore_workspace="$artifacts_folder/$current_date/$contract_name"

--- a/scripts/mythril-analyze.sh
+++ b/scripts/mythril-analyze.sh
@@ -36,7 +36,7 @@ main() {
   for contract_name in $contract_names;
   do
     echo "Analyzing '$contract_name'…"
-    contract_path="$sources_path/$contract_name.sol"
+    contract_path="$PREPROCESSED_CONTRACTS_PATH/$contract_name.sol"
     analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
     analysis_log_path="$artifacts_folder/$analysis_log_filename"
 

--- a/scripts/slither-analyze.sh
+++ b/scripts/slither-analyze.sh
@@ -28,7 +28,7 @@ main() {
   for contract_name in $contract_names;
   do 
     echo "Testing: '$contract_name'…"
-    source_contract_path="$sources_path/$contract_name.sol"
+    source_contract_path="$PREPROCESSED_CONTRACTS_PATH/$contract_name.sol"
     analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
     analysis_log_path="$artifacts_folder/$analysis_log_filename"
 


### PR DESCRIPTION
- Fix the contract path used for analysing contracts. Before the fix,
  the tools were targeting source paths contracts instead of
  preprocessed contracts under `tmp` path. Preprocessing is important as
  it removes non-prod-relevant calls such as `console.log`.
