### PR TITLE
Fix: Minor issues with analysis tool scripts

### DIFF
--- a/scripts/echidna-analyze.sh
+++ b/scripts/echidna-analyze.sh
@@ -30,7 +30,8 @@ main() {
 
     if [ ! -f "$fuzz_contract_path" ];
     then
-      echo "$fuzz_contract_path is not available, skipping"
+      echo "$fuzz_contract_path is not available, skipping" \
+        | tee "$analysis_log_path"
       continue 
     fi
 

--- a/scripts/slither-analyze.sh
+++ b/scripts/slither-analyze.sh
@@ -31,8 +31,14 @@ main() {
     source_contract_path="$PREPROCESSED_CONTRACTS_PATH/$contract_name.sol"
     analysis_log_filename="$contract_name-$current_date.$ANALYSIS_LOG_SUFFIX"
     analysis_log_path="$artifacts_folder/$analysis_log_filename"
+    analysis_json_log_path="$artifacts_folder/$analysis_log_filename.json"
 
-    slither "$source_contract_path" | tee "$analysis_log_path"
+    slither \
+      --show-ignored-findings \
+      --config-file ./slither.config.json \
+      --json $analysis_json_log_path \
+      "$source_contract_path" \
+      2>&1 | tee "$analysis_log_path"
 
     echo "Analysis log is available at '$analysis_log_path'"
     echo "Finished: '$contract_name'"


### PR DESCRIPTION
- Alter slither call to customize the run much more effectively. Now it
  uses the config file, produces an additional json output and properly
  saves the log through `tee`. It also outputs all the findings instead
  of just what slither decides to be important.
- Alter echidna log output to include a line if the test for a
  particular contract is being skipped in case there is no fuzz contract
  to run on.
