### PR TITLE
Feat: Enable gas reporter by default

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,6 @@
 features:
   gasReporter:
-    enabled: false
+    enabled: true
     token: eth
   multiUserTesting: false
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -116,8 +116,10 @@ const hardhatConfig: HardhatUserConfig = {
 
   ...(config.has("apiKeys.coinMarketCap") && {
     gasReporter: {
+      outputFile: `artifacts/gas-reporter/gas-usage.${Math.floor(Date.now()/1e3)}.log`,
       token: config.get<string>("features.gasReporter.token"),
       enabled: config.get<boolean>("features.gasReporter.enabled"),
+      noColors: true,
       coinmarketcap: config.get<string>("apiKeys.coinMarketCap"),
       currency: "USD",
     },


### PR DESCRIPTION
- Enable config setting for running gas reporter.
- Enable artifact creation for gas reporter under
  `artifacts/gas-reporter` with a filename that includes the epoch. The
  use of epoch is a diversion from the use of human-readable dates that
  are published by other analysis tools but this is done to keep the
  config file concise. This can later be replaced by a human readable
  format.
