### PR TITLE
Chore: Update default compiler settings for Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "solidity.compileUsingRemoteVersion": "v0.8.7+commit.e28d00a7",
+  "solidity.compileUsingRemoteVersion": "v0.8.16+commit.07a7930e",
+  "solidity.defaultCompiler": "remote",
   "runOnSave.commands": [
     {
       "match": "\\.env(\\.\\w+)?$",


### PR DESCRIPTION
- Update default compiler version as `v0.8.16+commit.07a7930e` the
  compiler as `remote` in VS Code settings.
